### PR TITLE
SUP-1355 Check for item data

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,12 @@ module.exports = (function () {
   }
 
   var getFilesForItem = function (item, callback) {
+      // If no data is available for the item, return.
+      if (!item || !item.data) {
+         callback(item);
+         return;
+      }
+
       var relevantElements = []
       if (Array.isArray(item.data.config)) {
           item.data.config.forEach(c => {


### PR DESCRIPTION
When retrieving the files associated with the content item, we found sometimes the data property would not be there. This exits early on that case, since there are no files associated with the data.